### PR TITLE
Add pageLimit parameter to site pages.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -319,6 +319,9 @@ module.exports = class Waffel extends EventEmitter
         .chunk(page.paginate or @options.defaultPagination)
         .value()
 
+      if page.pageLimit
+        pages = pages.slice 0, Math.abs +page.pageLimit
+
       pages.map (p, index) =>
         _page = _.clone page
         _page.pagination =

--- a/test/default/structure.coffee
+++ b/test/default/structure.coffee
@@ -57,6 +57,10 @@ describe 'Output structure', ->
         .sort()
       dataTags.toString().should.equal generatedTags.toString()
 
+    it "should limit page number", ->
+      destinationFolder = path.join wfl.options.destinationFolder, blogPage.pages.feed.url
+      glob.sync('*.html', cwd: destinationFolder).length.should.be.exactly 1
+
     it "should paginate posts", ->
       destinationFolder = path.join wfl.options.destinationFolder, blogPage.pages.index.url
       pageRootFolder = path.join destinationFolder, 'page'

--- a/test/fixtures/site_default.yml
+++ b/test/fixtures/site_default.yml
@@ -17,6 +17,14 @@ structure:
         sort:
           field: date
           order: desc
+      feed:
+        template:   blog/index
+        url:        /blog/feed
+        sitemap:    false
+        pageLimit:  1
+        sort:
+          field: date
+          order: desc
       categories:
         template: blog/category
         url:      /blog/category/:category


### PR DESCRIPTION
If a `pageLimit`amount is defined in a page configuration, just that many pages will be rendered.

Quite useful when rendering RSS feeds for instances, e.g.:

```
  feed:
    template:   blog/feed
    url:        /blog/feed.xml
    sitemap:    false
    paginate:    15
    pageLimit:  1
    filter:
      published: true
    sort:
      field: date
      order: desc
```

This configuration will generate a feed of the latest 15 published posts.
